### PR TITLE
add docker code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,6 @@ test:
 		make test -C $$prog; \
 	done
 docker:
-	git clone https://github.com/IvanTsers/neighbors-docker; \
-	cd neighbors-docker; \
+	cd docker; \
 	sudo docker build -t neighbors .; \
 	cd ..

--- a/README.md
+++ b/README.md
@@ -40,14 +40,12 @@ and `texlive-fonts-extra`. Then execute
 ## Run Docker Container 
 As an alternative to building `neighbors` from scratch, we also post it as a [docker
   container](https://hub.docker.com/r/itsers/neighbors). The container
-  includes all programs needed to work through the tutorial in `~/tutorial.txt`.
+  includes all programs needed to work through the tutorial in `neighborsDoc.pdf`.
   -  `$ docker pull itsers/neighbors`
   -  `$ docker container run --detach-keys="ctrl-@" -h neighbors -it itsers/neighbors`
 ## Make the Docker Container
 The command  
 `$ make docker`  
-pulls the repository
-`https://github.com/IvanTsers/neighbors-docker`, and starts building a
-local copy of the docker image.
+starts building a local copy of the docker image.
 ## License
 [GNU General Public License](https://www.gnu.org/licenses/gpl.html)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,25 @@
+FROM debian:stable-slim
+
+RUN useradd -m -p NbqDBxZy0F.tE -s /bin/bash jdoe
+
+RUN usermod -aG sudo jdoe
+
+COPY install.sh .
+
+COPY README.md /home/jdoe/
+
+RUN ["chmod", "+x", "./install.sh"]
+
+RUN ./install.sh
+
+RUN chown -R jdoe /home/jdoe/
+
+RUN chgrp -R jdoe /home/jdoe/
+
+WORKDIR /home/jdoe
+
+USER jdoe
+
+ENV HOME /home/jdoe
+
+

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,122 @@
+## Introduction
+
+This container includes pre-compiled programs from the EvolBioInf
+github repository (https://github/evolbioinf) for marker sequence
+search using whole genome sequences:
+
+- `Neighbors` package (find taxonomic neighbors)
+- `phylonium` (fast genetic distance calculation)
+- `fur` package (find unique genomic regions)
+- `biobox` package (manipulate sequences, trees, etc.)
+
+Auxiliary tools on-board:
+
+- `datasets` package (access NCBI databases from Unix CLI)
+- `blast+` (pairwise sequence alignment)
+- `gnuplot` (draw plots, in particular, phylogenetic trees)
+
+## Installation
+    
+To install the container:
+
+    docker pull itsers/neighbors
+
+## Preparing host machine
+    
+Enable X11 connections to allow docker containers to display plots on
+the screen:
+
+    xhost +
+
+This message should appear upon successful execution:
+
+    'access control disabled, clients can connect from any host'.
+
+## Running the container
+
+We recommend these options to run the container:
+
+    docker run -it --env="DISPLAY" --net=host -v
+    ~/neighbors_share:/home/jdoe/neighbors_share -h neighbors
+    --detach-keys="ctrl-@" itsers/neighbors
+
+When container is turned on successfully, you will see your username
+changed to `jdoe`, and the host name changed to `neighbors` in the
+current shell instance:
+
+    >jdoe@neighbors:~$
+
+The initial user password for jdoe is: `password`.
+
+To stop the container and return to the host shell, type `exit` or
+press `Ctrl+D`.
+
+The flags usage explained:
+
+- `-it` runs the container in CLI interactive mode
+
+- `--env="DISPLAY"` and `--net=host`: these are needed to display
+    graphic output from inside the container
+
+- `-v ~/neighbors_share:/home/jdoe/neighbors`: this creates a folder
+shared between the neighbors container (`/home/jdoe/neighbors_share`)
+and your `/home` directory (`/home/username/neighbors_share`). With
+this, you can use the container to operate with your own data and save
+the results on your machine that hosts the container. Just make sure
+that you have saved your results at `/home/jdoe/neighbors_share`
+before stopping the container.
+
+- `--detach-keys="ctrl-@"` is used here to override the default key
+sequence (`Ctrl+P, Ctrl+Q`) with `Ctrl+Shift+2` for switching between
+interactive mode and daemon (background) mode. This frees the sequence
+`Ctrl+P` to be used alongside with `Ctrl+N` to navigate the shell
+command history within the container.
+
+`-h neighbors` sets the host name inside the container.
+
+## Documentation and tutorial
+
+There is a file `neighborsDoc.pdf` at `/home/jdoe` describing the
+programs of the `neqighbors` package and providing a tutorial on
+neighbors-based analysis. You can move or copy the file to the
+`/home/jdoe/neighbors_share` folder and open it in your host operating
+system. If you want to open the PDF within the container, install a
+PDF viewer (for example, evince) inside the container:
+
+	apt-get install evince
+	evince neighborsDoc.pdf
+
+Make sure that X11 connections are enabled beforehand (see above).
+
+## Contacts
+
+If you experience problems with the container, please open an issue at
+`https://github.com/EvolBioInf/neighbors`.  To report bugs and errors
+from `neighbors`, `fur`, or `biobox` specifically, please open issues
+in the respective GitHub repos:
+`https://github.com/EvolBioInf/neighbors`,
+`https://github.com/EvolBioInf/fur`, or
+`https://github.com/EvolBioInf/biobox`.
+
+## References
+**Haubold, B., Klötzl, F., Hellberg, L., Thompson, D., &
+Cavalar, M. (2021)**. Fur: Find unique genomic regions for diagnostic
+PCR. *Bioinformatics, 37(15),
+2081-2087*. (https://doi.org/10.1093/bioinformatics/btab059)
+
+**Klötzl, F., & Haubold, B. (2020)**. Phylonium: fast estimation of
+  evolutionary distances from large samples of similar
+  genomes. *Bioinformatics, 36(7),
+  2040-2046*. (https://doi.org/10.1093/bioinformatics/btz903)
+
+https://github.com/EvolBioInf/biobox
+
+**Kans, J. (2022)**. Entrez direct: E-utilities on the UNIX command
+  line. *In Entrez Programming Utilities Help [Internet]. National
+  Center for Biotechnology Information
+  (US)*. (https://www.ncbi.nlm.nih.gov/books/NBK179288/)
+
+**National Center for Biotechnology Information (US), & Camacho,
+  C. (2008)**. BLAST (r) Command Line Applications User Manual
+  (p. 30). *National Center for Biotechnology Information
+  (US)*. (https://www.ncbi.nlm.nih.gov/books/NBK279690/)

--- a/docker/install.sh
+++ b/docker/install.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+
+# install dependencies and additional programs
+apt-get update
+apt-get -y upgrade
+apt-get -y install apt-utils sudo wget git make cmake unzip \
+	autoconf build-essential noweb less pkg-config \
+	libgsl-dev libdivsufsort-dev libdivsufsort3 \
+	libbsd-dev libbsd-dev libgsl-dev libsdsl-dev \
+	ncbi-blast+ graphviz gnuplot texlive-science \
+	texlive-pstricks texlive-latex-extra texlive-fonts-extra
+apt-get clean
+
+# find and install current golang version
+gotar=$(wget -O- https://go.dev/dl/?mode=json | grep -o 'go.*.linux-amd64.tar.gz' | head -n 1)
+wget https://go.dev/dl/$gotar
+tar -C /usr/local -xzf $gotar
+export PATH=$PATH:/usr/local/go/bin
+rm $gotar
+
+# install NCBI datasets
+wget "https://ftp.ncbi.nlm.nih.gov/pub/datasets/command-line/v2/linux-amd64/datasets"
+mv datasets /usr/local/bin/
+chmod +x /usr/local/bin/datasets
+
+cd /home/jdoe
+
+# install biobox
+git clone https://github.com/evolbioinf/biobox
+cd biobox
+make
+cp bin/* /usr/local/bin
+cd /home/jdoe
+rm -rf biobox
+   
+# install neighbors
+git clone https://github.com/EvolBioInf/neighbors
+cd neighbors
+make
+cp ./bin/* /usr/local/bin
+
+# compile neighbors docs with the tutorial
+make doc
+mv doc/neighborsDoc.pdf /home/jdoe
+cd /home/jdoe
+rm -rf neighbors
+
+# install phylonium
+git clone https://github.com/evolbioinf/phylonium
+cd phylonium
+autoreconf -fi -Im4
+./configure
+make
+make install
+cd /home/jdoe
+rm -rf phylonium
+
+# install macle
+git clone https://github.com/simongog/sdsl-lite
+cd sdsl-lite
+./install.sh
+cd /home/jdoe
+rm -rf sdsl-lite
+
+git clone https://github.com/EvolBioInf/macle
+cd macle
+make
+cp ./build/macle /usr/local/bin/macle
+cd /home/jdoe
+rm -rf macle
+
+# install fur
+apt-get -y install gnuplot 
+git clone https://github.com/EvolBioInf/fur
+cd fur
+make
+cp bin/* /usr/local/bin
+cd /home/jdoe
+rm -rf fur
+
+# make a folder in /home/jdoe to share it with the host
+mkdir neighbors_share
+
+# remove dependencies that are no more necessary
+rm -rf /install.sh /usr/local/go /root/go* /root/.cache \
+    /usr/lib/go* /usr/share/go* /usr/share/icons
+
+apt-get -y remove \
+	git texlive-latex-extra texlive-fonts-recommended texlive-fonts-extra \
+	texlive-base texlive-latex-recommended texlive-pstricks texlive-science \
+    
+apt-get -y autoremove
+apt-get clean

--- a/tutorial/ec2.ps
+++ b/tutorial/ec2.ps
@@ -705,7 +705,7 @@ LCb setrgbcolor
 1.000 UP
 LCb setrgbcolor
 210 721 M
-[ [(Helvetica) 140.0 0.0 true true 0 ( 291)]
+[ [(Helvetica) 140.0 0.0 true true 0 ( 292)]
 ] -46.7 MLshow
 /Helvetica findfont 140 scalefont setfont
 /vshift -46 def
@@ -716,12 +716,12 @@ LCb setrgbcolor
 /Helvetica findfont 140 scalefont setfont
 LCb setrgbcolor
 2503 1274 M
-[ [(Helvetica) 140.0 0.0 true true 0 ( 292)]
+[ [(Helvetica) 140.0 0.0 true true 0 ( 293)]
 ] -46.7 MLshow
 /Helvetica findfont 140 scalefont setfont
 LCb setrgbcolor
 2688 485 M
-[ [(Helvetica) 140.0 0.0 true true 0 ( 293)]
+[ [(Helvetica) 140.0 0.0 true true 0 ( 294)]
 ] -46.7 MLshow
 /Helvetica findfont 140 scalefont setfont
 LCb setrgbcolor
@@ -731,7 +731,7 @@ LCb setrgbcolor
 /Helvetica findfont 140 scalefont setfont
 LCb setrgbcolor
 2733 643 M
-[ [(Helvetica) 140.0 0.0 true true 0 ( 294)]
+[ [(Helvetica) 140.0 0.0 true true 0 ( 295)]
 ] -46.7 MLshow
 /Helvetica findfont 140 scalefont setfont
 LCb setrgbcolor
@@ -741,7 +741,7 @@ LCb setrgbcolor
 /Helvetica findfont 140 scalefont setfont
 LCb setrgbcolor
 2751 799 M
-[ [(Helvetica) 140.0 0.0 true true 0 ( 295)]
+[ [(Helvetica) 140.0 0.0 true true 0 ( 296)]
 ] -46.7 MLshow
 /Helvetica findfont 140 scalefont setfont
 LCb setrgbcolor
@@ -751,7 +751,7 @@ LCb setrgbcolor
 /Helvetica findfont 140 scalefont setfont
 LCb setrgbcolor
 2774 954 M
-[ [(Helvetica) 140.0 0.0 true true 0 ( 296)]
+[ [(Helvetica) 140.0 0.0 true true 0 ( 297)]
 ] -46.7 MLshow
 /Helvetica findfont 140 scalefont setfont
 LCb setrgbcolor
@@ -761,7 +761,7 @@ LCb setrgbcolor
 /Helvetica findfont 140 scalefont setfont
 LCb setrgbcolor
 2793 1103 M
-[ [(Helvetica) 140.0 0.0 true true 0 ( 297)]
+[ [(Helvetica) 140.0 0.0 true true 0 ( 298)]
 ] -46.7 MLshow
 /Helvetica findfont 140 scalefont setfont
 LCb setrgbcolor
@@ -771,7 +771,7 @@ LCb setrgbcolor
 /Helvetica findfont 140 scalefont setfont
 LCb setrgbcolor
 2845 1242 M
-[ [(Helvetica) 140.0 0.0 true true 0 ( 298)]
+[ [(Helvetica) 140.0 0.0 true true 0 ( 299)]
 ] -46.7 MLshow
 /Helvetica findfont 140 scalefont setfont
 LCb setrgbcolor
@@ -781,7 +781,7 @@ LCb setrgbcolor
 /Helvetica findfont 140 scalefont setfont
 LCb setrgbcolor
 2858 1361 M
-[ [(Helvetica) 140.0 0.0 true true 0 ( 299)]
+[ [(Helvetica) 140.0 0.0 true true 0 ( 300)]
 ] -46.7 MLshow
 /Helvetica findfont 140 scalefont setfont
 LCb setrgbcolor
@@ -796,12 +796,12 @@ LCb setrgbcolor
 /Helvetica findfont 140 scalefont setfont
 LCb setrgbcolor
 2714 2063 M
-[ [(Helvetica) 140.0 0.0 true true 0 ( 300)]
+[ [(Helvetica) 140.0 0.0 true true 0 ( 301)]
 ] -46.7 MLshow
 /Helvetica findfont 140 scalefont setfont
 LCb setrgbcolor
 2761 1679 M
-[ [(Helvetica) 140.0 0.0 true true 0 ( 301)]
+[ [(Helvetica) 140.0 0.0 true true 0 ( 302)]
 ] -46.7 MLshow
 /Helvetica findfont 140 scalefont setfont
 LCb setrgbcolor
@@ -816,12 +816,12 @@ LCb setrgbcolor
 /Helvetica findfont 140 scalefont setfont
 LCb setrgbcolor
 2762 2446 M
-[ [(Helvetica) 140.0 0.0 true true 0 ( 302)]
+[ [(Helvetica) 140.0 0.0 true true 0 ( 303)]
 ] -46.7 MLshow
 /Helvetica findfont 140 scalefont setfont
 LCb setrgbcolor
 2878 1998 M
-[ [(Helvetica) 140.0 0.0 true true 0 ( 303)]
+[ [(Helvetica) 140.0 0.0 true true 0 ( 304)]
 ] -46.7 MLshow
 /Helvetica findfont 140 scalefont setfont
 LCb setrgbcolor
@@ -836,12 +836,12 @@ LCb setrgbcolor
 /Helvetica findfont 140 scalefont setfont
 LCb setrgbcolor
 2815 2895 M
-[ [(Helvetica) 140.0 0.0 true true 0 ( 304)]
+[ [(Helvetica) 140.0 0.0 true true 0 ( 305)]
 ] -46.7 MLshow
 /Helvetica findfont 140 scalefont setfont
 LCb setrgbcolor
 2884 2440 M
-[ [(Helvetica) 140.0 0.0 true true 0 ( 305)]
+[ [(Helvetica) 140.0 0.0 true true 0 ( 306)]
 ] -46.7 MLshow
 /Helvetica findfont 140 scalefont setfont
 LCb setrgbcolor
@@ -851,7 +851,7 @@ LCb setrgbcolor
 /Helvetica findfont 140 scalefont setfont
 LCb setrgbcolor
 2887 2643 M
-[ [(Helvetica) 140.0 0.0 true true 0 ( 306)]
+[ [(Helvetica) 140.0 0.0 true true 0 ( 307)]
 ] -46.7 MLshow
 /Helvetica findfont 140 scalefont setfont
 LCb setrgbcolor
@@ -861,12 +861,12 @@ LCb setrgbcolor
 /Helvetica findfont 140 scalefont setfont
 LCb setrgbcolor
 2889 2892 M
-[ [(Helvetica) 140.0 0.0 true true 0 ( 307)]
+[ [(Helvetica) 140.0 0.0 true true 0 ( 308)]
 ] -46.7 MLshow
 /Helvetica findfont 140 scalefont setfont
 LCb setrgbcolor
 2892 2674 M
-[ [(Helvetica) 140.0 0.0 true true 0 ( 308)]
+[ [(Helvetica) 140.0 0.0 true true 0 ( 309)]
 ] -46.7 MLshow
 /Helvetica findfont 140 scalefont setfont
 LCb setrgbcolor
@@ -876,7 +876,7 @@ LCb setrgbcolor
 /Helvetica findfont 140 scalefont setfont
 LCb setrgbcolor
 2893 2793 M
-[ [(Helvetica) 140.0 0.0 true true 0 ( 309)]
+[ [(Helvetica) 140.0 0.0 true true 0 ( 310)]
 ] -46.7 MLshow
 /Helvetica findfont 140 scalefont setfont
 LCb setrgbcolor
@@ -891,7 +891,7 @@ LCb setrgbcolor
 /Helvetica findfont 140 scalefont setfont
 LCb setrgbcolor
 2891 3111 M
-[ [(Helvetica) 140.0 0.0 true true 0 ( 310)]
+[ [(Helvetica) 140.0 0.0 true true 0 ( 311)]
 ] -46.7 MLshow
 /Helvetica findfont 140 scalefont setfont
 LCb setrgbcolor
@@ -906,7 +906,7 @@ LCb setrgbcolor
 /Helvetica findfont 140 scalefont setfont
 LCb setrgbcolor
 2833 3350 M
-[ [(Helvetica) 140.0 0.0 true true 0 ( 311)]
+[ [(Helvetica) 140.0 0.0 true true 0 ( 312)]
 ] -46.7 MLshow
 /Helvetica findfont 140 scalefont setfont
 LCb setrgbcolor

--- a/tutorial/tutorial.org
+++ b/tutorial/tutorial.org
@@ -126,7 +126,7 @@ genome sequences.
 \end{figure}
 #+end_export
 #+begin_src sh <<query.sh>>=
-  dree 83334 neidb
+  dree 83334 neidb | dot -T x11
 #+end_src
 #+begin_export latex
 We saw previously that the parent of 83334 is taxon 562. To find out
@@ -301,10 +301,15 @@ genomes. It is available from the \ty{datasets} web site,
 \end{center}
 We restrict our analysis to genomes with assembly-level ``complete''
 and exclude genomes flagged as ``atypical''. We download the genomes
-in ``dehydrated'' form. We begin with the target genomes, of which
-there are 143. This means out of the 329 target genomes across all
-assembly levels, only 143 are typical and complete. We save the target
-genomes in \ty{tdata.zip}.
+in ``dehydrated'' form. \textbf{Attention:} the data were accessed on
+31 January 2024. The number of available genomes of interest may, of
+course, change with time. This can affect the downstream analysis, so
+one should keep track of it. In this tutorial, we proceed with the
+data available on the given date.
+
+We begin with the target genomes, of which there are 143. This means
+out of the 329 target genomes across all assembly levels, only 143 are
+typical and complete. We save the target genomes in \ty{tdata.zip}.
 #+end_export
 #+begin_src sh <<query.sh>>=
   datasets download genome accession \
@@ -315,8 +320,8 @@ genomes in \ty{tdata.zip}.
 	   --filename tdata.zip
 #+end_src
 #+begin_export latex
-We repeat the download for the neighbor genomes, where only 306 out of
-the 3127 pass muster.
+We repeat the download for the neighbor genomes, where only 307 out of
+the 3128 pass muster.
 #+end_export
 #+begin_src sh <<query.sh>>=
   datasets download genome accession \
@@ -346,7 +351,7 @@ We rehydrate the 143 target genomes.
   datasets rehydrate --directory tdata
 #+end_src
 #+begin_export latex
-We rehydrate the 306 neighbor genomes.
+We rehydrate the 307 neighbor genomes.
 #+end_export
 #+begin_src sh <<query.sh>>=
   datasets rehydrate --directory ndata
@@ -404,7 +409,7 @@ part of Neighbors, and save the final tree in \ty{o157.nwk}.
 The tree in \ty{o157.nwk} is in the popular Newick format, and you can
 render it with your favorite tree plotting program. One example of
 such a program is \ty{plotTree} from the biobox. Its default plot
-dimensions are too small for our tree of 449 taxa, so we set the
+dimensions are too small for our tree of 450 taxa, so we set the
 dimensions to $1200\times 1200$ pixels.
 #+end_export
 #+begin_src sh <<query.sh>>=
@@ -421,7 +426,7 @@ that the targets are concentrated in the top part of the tree.
 #+end_src
 #+begin_export latex
 To further explore the target region of our tree, let's pick the
-subtree rooted on node 268 as it appears to contain most targets and a
+subtree rooted on node 269 as it appears to contain most targets and a
 bit of neighbor context. We do this with \ty{pickle} in tree mode,
 \ty{-t}. We now see that node 291 contains a lone target, while its
 other child, node 292, contains most of the targets and a closely
@@ -429,17 +434,17 @@ related neighbor clade.
 #+end_export
 #+begin_src sh <<query.sh>>=
   sed 's/n[^f]*fna/n/g' o157.nwk |
-      pickle -t 268 |
+      pickle -t 269 |
       plotTree -d 1200,1200 
 #+end_src
 #+begin_export latex
 To make the target clade easier to read, we further zoom into it by
-picking node 292. This shows us that the targets are in clade 300,
-while its sister clade 293 contains eight neighbors.
+picking node 293. This shows us that the targets are in clade 301,
+while its sister clade 294 contains eight neighbors.
 #+end_export
 #+begin_src sh <<query.sh>>=
   sed 's/n[^f]*fna/n/g' o157.nwk |
-      pickle -t 292 |
+      pickle -t 293 |
       plotTree -d 1200,1200 
 #+end_src
 #+begin_export latex
@@ -448,7 +453,7 @@ neighbors interspersed in our target clade. We count nine such
 misclassified taxa, which we treat as targets in subsequent analyses.
 #+end_export
 #+begin_src sh <<query.sh>>=
-  pickle 300 o157.nwk |
+  pickle 301 o157.nwk |
       grep -c '^n'
 #+end_src
 #+begin_export latex
@@ -464,7 +469,7 @@ both the leaf labels and node labels. Nodes can be removed by using
 #+end_src
 #+begin_export latex
 Now we also reduce the target labels to their first character and plot
-the reduced tree rooted on 291 shown in Figure~\ref{fig:o157}.
+the reduced tree rooted on 292 shown in Figure~\ref{fig:o157}.
 \begin{figure}
 \begin{center}
 \includegraphics{../tutorial/ec2.ps}
@@ -476,12 +481,12 @@ the reduced tree rooted on 291 shown in Figure~\ref{fig:o157}.
 #+end_export
 #+begin_src sh <<query.sh>>=
   sed -E 's/([nt])[^f]*fna/\1/g' o157.nwk |
-      pickle -t 291 |
+      pickle -t 292 |
       pickle -t -c 312 |
       plotTree -d 1200,1200
 #+end_src
 #+begin_export latex
-In Figure~\ref{fig:o157} clade 300 is our target clade, which took us
+In Figure~\ref{fig:o157} clade 301 is our target clade, which took us
 a while to discover. Our discovery process is encapsulated in the
 program \ty{fintac}, which finds the target clade by looking for the
 clade that maximizes the sum of the targets inside its subtree and the
@@ -492,8 +497,8 @@ neighbors outside.
 #+end_src
 #+begin_export latex
 \begin{verbatim}
-#Clade  Parent  Split (%)
-300     292     97.6
+#Clade  Targets  Neighbors  Split (%)  Parent  Dist(Parent)
+301     141      9          97.6       293     0.00046
 \end{verbatim}
 We can also use the \ty{-a} option of \ty{fintac} to list all splits.
 #+end_export
@@ -502,24 +507,20 @@ We can also use the \ty{-a} option of \ty{fintac} to list all splits.
 #+end_src
 #+begin_export latex
 \begin{verbatim}
-#Clade  Parent  Split (%)
-300     292     97.6
-302     300     97.1
-304     302     96.7
-291     290     96.0
-290     271     95.8
-292     291     95.8
-311     304     95.1
-312     311     94.9
-271     270     91.5
+#Clade   Neighbors  Split (%)  Parent  Dist(Parent)
+301      9          97.6       293     0.00046
+303      9          97.1       301     0.000106
+305      9          96.7       303     0.000115
+292      17         96.0       291     0.000471
+...
 \end{verbatim}
-The closely related sister clade of 300, 293, is made up of
-neighbors. As we already noted, the root of this partial tree, 291, is
+The closely related sister clade of 301, 294, is made up of
+neighbors. As we already noted, the root of this partial tree, 292, is
 connected to a singleton branch leading to a target. This is one of
-two taxonomic targets outside of clade 300.
+two taxonomic targets outside of clade 301.
 #+end_export
 #+begin_src sh <<query.sh>>=
-  pickle -c 300 o157.nwk | grep '^t'
+  pickle -c 301 o157.nwk | grep '^t'
 #+end_src
 #+begin_export latex
 \begin{verbatim}
@@ -528,11 +529,11 @@ tGCA_003722195.1_ASM372219v1_genomic.fna
 \end{verbatim}
 
 Since the distance between this lone putative target and
-the many targets in clade 300 is substantial, we reassign the loner as
+the many targets in clade 301 is substantial, we reassign the loner as
 a neighbor.
 
 We begin our search for markers by splitting our tree into targets,
-i. e. clade 300, and neighbors, the precise difinition of which comes
+i. e. clade 301, and neighbors, the precise difinition of which comes
 later.
 
 To separate the targets, we make a directory, \ty{targets}. Then we
@@ -541,7 +542,7 @@ clade. For each taxon we create a symbolic link to the original data.
 #+end_export
 #+begin_src sh <<query.sh>>=
   mkdir targets
-  pickle 300 o157.nwk |
+  pickle 301 o157.nwk |
       grep -v '^#' |
       while read a; do
 	  ln -s $(pwd)/all/$a $(pwd)/targets/$a
@@ -550,11 +551,11 @@ clade. For each taxon we create a symbolic link to the original data.
 #+begin_export latex
 The program \ty{fur} works on the idea that the \emph{closest}
 neighbors are the most informative for marker discovery. So we
-construct our neighbor set from the genomes in clade 293.
+construct our neighbor set from the genomes in clade 294.
 #+end_export
 #+begin_src sh <<query.sh>>=
   mkdir neighbors
-  pickle 293 o157.nwk |
+  pickle 294 o157.nwk |
       grep -v '^#' |
       while read a; do
 	  ln -s $(pwd)/all/$a $(pwd)/neighbors/$a
@@ -563,59 +564,59 @@ construct our neighbor set from the genomes in clade 293.
 #+begin_export latex
 In preparation for running \ty{fur}, we make its database with
 \ty{makeFurDb}. Since the database is used to compare the targets in
-node 300 with the neighbors in node 293, we call it \ty{300\_293.db}. Its
+node 301 with the neighbors in node 294, we call it \ty{301\_294.db}. Its
 construction takes approximately 25 s.
 #+end_export
 #+begin_src sh <<query.sh>>=
-  makeFurDb -t targets/ -n neighbors/ -d 300_293.db
+  makeFurDb -t targets/ -n neighbors/ -d 301_294.db
 #+end_src
 #+begin_export latex
 Given the database, we can apply \ty{fur} to it. This takes nine
-seconds and returns 8.6 kb marker candidates, of which 2.2 kb are
-\ty{N}s. We save these sequences in the file \ty{300\_293.fasta}.
+seconds and returns 8.5 kb marker candidates, of which 2 kb are
+\ty{N}s. We save these sequences in the file \ty{301\_294.fasta}.
 #+end_export
 #+begin_src sh <<query.sh>>=
-  fur -d 300_293.db > 300_293.fasta
+  fur -d 301_294.db > 301_294.fasta
 #+end_src
 #+begin_export latex
 \begin{verbatim}
   Step           Sequences  Length    Ns
   -------------  ---------  ------    --
-  Subtraction_1        247  226718     0
-  Intersection          44   16383   504
-  Subtraction_2         12    8668  2201
+  Subtraction_1        248  230358     0
+  Intersection          41   16772   578
+  Subtraction_2         12    8525  2047
 \end{verbatim}
 
 To check whether these markers crosshybridize with markers in the
 wider neighborhood, we repeat the analysis with a neighborhood
-consisting of everything but node 300 making up the neighborhood.
+consisting of everything but node 301 making up the neighborhood.
 #+end_export
 #+begin_src sh <<query.sh>>=
   rm neighbors/*
-  pickle -c 300 o157.nwk |
+  pickle -c 301 o157.nwk |
       grep -v '^#' |
       while read a; do
 	  ln -s $(pwd)/all/$a $(pwd)/neighbors/$a
       done
 #+end_src
 #+begin_export latex
-The new database compares clade 300 to everything else in the tree, so
-we call it \ty{300.db}. Its construction takes 13.5 minutes.
+The new database compares clade 301 to everything else in the tree, so
+we call it \ty{301.db}. Its construction takes 13.5 minutes.
 #+end_export
 #+begin_src sh <<query.sh>>=
-  makeFurDb -t targets -n neighbors -d 300.db
+  makeFurDb -t targets -n neighbors -d 301.db
 #+end_src
 #+begin_export latex
 Now the intersection step of \ty{fur} comes up empty.
 #+end_export
 #+begin_src sh <<query.sh>>=
-  fur -d 300.db
+  fur -d 301.db
 #+end_src
 #+begin_export latex
 \begin{verbatim} 
   Step           Sequences  Length  Ns
   -------------  ---------  ------  --
-  Subtraction_1         30   24281   0
+  Subtraction_1         25   24244   0
   Intersection           0       0   0
 \end{verbatim}
 
@@ -670,15 +671,16 @@ subtraction step.
 #+begin_src sh <<query.sh>>=
   awk '$2==4.869019e+06' tlen.dat
   rm targets/tGCA_030908645.1_ASM3090864v1_genomic.fna
-  makeFurDb -t targets -n neighbors -o -d 300.db
-  fur -d 300.db
+  makeFurDb -t targets -n neighbors -o -d 301.db
+  fur -d 301.db
 #+end_src
 #+begin_export latex
+\clearpage
 \begin{verbatim}
   Step           Sequences  Length  Ns
   -------------  ---------  ------  --
-  Subtraction_1         39   28967   0
-  Intersection           7    2750  13
+  Subtraction_1         40   29376   0
+  Intersection           7    2781  12
   Subtraction_2          0       0   0
 \end{verbatim}
 #+end_export
@@ -689,54 +691,53 @@ sensitive megablast mode, which leaves two fragment with a total of
 210 bp. Not much, but much more than nothing.
 #+end_export
 #+begin_src sh <<query.sh>>=
-  fur -d -m 300.db
+  fur -m -d 301.db
 #+end_src
 #+begin_export latex
 \begin{verbatim}
-fur -m -d 300.db/ > 300.fasta
   Step           Sequences  Length  Ns
   -------------  ---------  ------  --
-  Subtraction_1         39   28967   0
-  Intersection           7    2750  13
+  Subtraction_1         40   29376   0
+  Intersection           7    2781  12
   Subtraction_2          2     210   0
 \end{verbatim}
 #+end_export
 #+begin_export latex
 In an attempt to improve our marker yield, we look for nested
 markers. Notice that in Figure~\ref{fig:o157} the branch separating
-node 291 from node 292 is much longer than the branch separating
-clades 300 and 293. So we begin our search for nested markers by again
-looking for regions that distinguish targets 300 from neighbors 293,
+node 292 from node 293 is much longer than the branch separating
+clades 301 and 294. So we begin our search for nested markers by again
+looking for regions that distinguish targets 301 from neighbors 294,
 only this time we don't include the extremely short genome. In a
 second step we'll compare targets 292 to everything else. But first we
-compare 300 vs. 293, which gives 13.3 kb markers with almost 5 kb
-\ty{N}s, up from 8.8 kb in our previous analysis.
+compare 301 vs. 294, which gives 13.1 kb markers with almost 5 kb
+\ty{N}s, up from 8.5 kb in our previous analysis.
 #+end_export
 #+begin_src sh <<query.sh>>=
   rm neighbors/*
-  pickle 293 o157.nwk |
+  pickle 294 o157.nwk |
 	grep -v '^#' |
 	while read a; do
 	    ln -s $(pwd)/all/$a $(pwd)/neighbors/$a
 	done
-  makeFurDb -t targets -n neighbors -d 300_293.db -o
-  fur -d 300_293.db > 300_293.fasta
+  makeFurDb -t targets -n neighbors -d 301_294.db -o
+  fur -d 301_294.db > 301_294.fasta
 #+end_src
 #+begin_export latex
 \begin{verbatim}
   Step           Sequences  Length    Ns
   -------------  ---------  ------    --
-  Subtraction_1        331  255255     0
-  Intersection         108   33484   691
-  Subtraction_2         15   13279  4863
+  Subtraction_1        340  258815     0
+  Intersection         114   35229   708
+  Subtraction_2         15   13126  4709
 \end{verbatim}
 
-Now we compare 292 to the rest. We begin by preparing the targets and
+Now we compare 293 to the rest. We begin by preparing the targets and
 remove the extra short genome.
 #+end_export
 #+begin_src sh <<query.sh>>=
   rm targets/*
-  pickle 292 o157.nwk |
+  pickle 293 o157.nwk |
       grep -v '^#' |
       while read a; do
 	  ln -s $(pwd)/all/$a $(pwd)/targets/$a
@@ -748,7 +749,7 @@ And now the neighbors.
 #+end_export
 #+begin_src sh <<query.sh>>=
   rm neighbors/*
-  pickle -c 292 o157.nwk |
+  pickle -c 293 o157.nwk |
       grep -v '^#' |
       while read a; do
 	  ln -s $(pwd)/all/$a $(pwd)/neighbors/$a
@@ -756,24 +757,24 @@ And now the neighbors.
 #+end_src
 #+begin_export latex
 We run \ty{makeFurDb} and \ty{fur} to find a very poor yield in
-default mode, but with megablast mode there are 3.2 kb markers, of
+default mode, but with megablast mode there are 4 kb markers, of
 which half a kb is \ty{N}s. That's a start.
 #+end_export
 #+begin_src sh <<query.sh>>=
-  makeFurDb -t targets -n neighbors -d 292.db
-  fur -m -d 292.db > 292.fasta
+  makeFurDb -t targets -n neighbors -d 293.db
+  fur -m -d 293.db > 293.fasta
 #+end_src
 #+begin_export latex
 \begin{verbatim}
   Step           Sequences  Length   Ns
   -------------  ---------  ------   --
-  Subtraction_1        218   78859    0
-  Intersection         107   18743  852
-  Subtraction_2         12    3188  555
+  Subtraction_1        246   82059    0
+  Intersection         112   19116  781
+  Subtraction_2         18    4021  556
 \end{verbatim}
 The next step in the design of diagnostic markers would be to
-construct PCR primers based on \ty{292.fasta} and
-\ty{300\_293.fasta}. We would then test \emph{in silico} the
+construct PCR primers based on \ty{293.fasta} and
+\ty{301\_294.fasta}. We would then test \emph{in silico} the
 specificity and sensitivity of the pair of primers in detecting
 \emph{E. coli} O157:H7. Any primers from the \emph{in silico} work
 would ultimately need to be tested in the lab.


### PR DESCRIPTION
Hello Bernhard,

I suggest integrating the docker code into the repository for uniformity (as in fur).
The old external repo on my account should be considered deprecated.
I also have updated the container image itself and updated the tutorial a bit.

Changes:
- the code for docker is migrating into this repository
- updated the contents of the docker image
- enabled automated installation of up-to-date golang for the docker image
- README for the docker image was rewritten
- included "less" to actually enalbe reading of the README
- inlcuded neighborsDoc.pdf
- updated Makefile
- updated repo's README with the stuff regarding docker

I've worked through the tutorial from the container, and noticed that it required an update as well.
- edits in the tutorial:
-- added a pipe from dree to dot (before the dot-rendered figure)
-- as of 31.01.2024, 307 neighbor genomes are being fetched by
	  `datasets` instead of 306.  I updated the references to clades
	  and all outputs accordingly.  In the future, the number of
	  genomes downloaded with datasets shall differ from the
	  tutorial significantly, with each new genome ruining clade
	  picking due to shifts in node labeling.  I do not see how to
	  make the datasets stuff more stable for the tutorial.
-- updated figure 4.2 (the reduced tree) with new node labels
-- some other little edits

Cheers,
Ivan